### PR TITLE
FIP-3090: Exclude trace prefix, when returning trace number.

### DIFF
--- a/lib/ach/records/addendum.rb
+++ b/lib/ach/records/addendum.rb
@@ -18,7 +18,7 @@ module ACH::Records
       end
 
       def original_entry_trace_number
-        payment_data[3..17]
+        payment_data[11..17]
       end
 
       def original_receiving_dfi_identification
@@ -39,7 +39,7 @@ module ACH::Records
       end
 
       def original_entry_trace_number
-        payment_data[3..17]
+        payment_data[11..17]
       end
 
       def date_of_death


### PR DESCRIPTION
https://financeit.atlassian.net/browse/FIP-3090
